### PR TITLE
ami: include pkgs.git

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
           {
             environment.systemPackages = [
               inputs.fh.packages.${system}.default
+              pkgs.git
             ];
           }
           {


### PR DESCRIPTION
Miscellaneous things I'm noticing.

~~1. We should probably just commit to using EFI.~~
2. We definitely should include `git`. I'm `nix build`ing and remembering that `git` flake inputs don't work if `git` is not in PATH.