### PR TITLE
update for rebased nixpkgs; determinate-nixd v0.2.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,52 +13,52 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1731448710,
-        "narHash": "sha256-uNxfr/i8m9oyMPUxlagmOm+qQ4erUB0Pq2sRtR4qFV4=",
-        "rev": "e8698104b97ce6bce0ce6bbd46d82dccabfffd1d",
-        "revCount": 153,
+        "lastModified": 1732231026,
+        "narHash": "sha256-tuqod7g+1+PvtUXUlLl4MwY9B+gr4rAEOGvhmhtWLbE=",
+        "rev": "29b7b7dfb1c878267383aa91c357ef464bef0f0d",
+        "revCount": 159,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.153%2Brev-e8698104b97ce6bce0ce6bbd46d82dccabfffd1d/01932265-56de-748a-a97e-9e8bfaab53a2/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.159%2Brev-29b7b7dfb1c878267383aa91c357ef464bef0f0d/01935106-420e-7097-93f6-ef4f1b11ffde/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/determinate/0.1.95"
+        "url": "https://flakehub.com/f/DeterminateSystems/determinate/0.1.%2A.tar.gz"
       }
     },
     "determinate-nixd-aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-XSYDoC2gHke98y83pABOnNT0E2jGE0qo1yBzY0b7/I0=",
+        "narHash": "sha256-6E9DFC4lTpjmErG2TvV7rIS1tiyGZZYg0Kd4pT5GOkU=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.2/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.4/macOS"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.2/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.4/macOS"
       }
     },
     "determinate-nixd-aarch64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-MfKT7oYAZ1BxVpsFA4SRNYxh+2fQScESO67UJy+8gQY=",
+        "narHash": "sha256-CnbFYAL7dAl8qBIvAFMVjW4KpQgmWlghnK3qfoLEP8Q=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.2/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.4/aarch64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.2/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.4/aarch64-linux"
       }
     },
     "determinate-nixd-x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-N6ufU3p/8ooUsElSmPTArgfqCWj0emuDdLgkCFZ1ksE=",
+        "narHash": "sha256-0w3gbvncDwukX4PHVWeOZeD6F6vsEuePoNOIlAvdEq0=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.2/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.4/x86_64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.2/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.4/x86_64-linux"
       }
     },
     "fenix": {
@@ -276,12 +276,12 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1731709036,
-        "narHash": "sha256-awazFZZVVLXYg0pBSp0rJC8C3zr7NA1AJblhrMDX/L0=",
-        "rev": "9be9fe18837f7b04c03df941e032894b1c055696",
-        "revCount": 215,
+        "lastModified": 1731926267,
+        "narHash": "sha256-kQWe2AZylGGODw99J+Y/NWdronPBuj11XuF5GS102bk=",
+        "rev": "b22b21357cf24d687c2cef4baf5011915124857a",
+        "revCount": 216,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/amis/0.1.215%2Brev-9be9fe18837f7b04c03df941e032894b1c055696/019331e7-aebb-769a-8c0e-2fae75651ddf/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/amis/0.1.216%2Brev-b22b21357cf24d687c2cef4baf5011915124857a/01933eda-5dd7-7ea0-8e93-c8cb9409600e/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -352,12 +352,12 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
-        "revCount": 704822,
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "revCount": 709559,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.704822%2Brev-85f7e662eda4fa3a995556527c87b2524b691933/01931edf-608b-7333-a7d9-7240678d1fba/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.709559%2Brev-5083ec887760adfe12af64830a66807423a859a7/019342ec-4762-77f2-9a11-86e7601b0be4/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -395,11 +395,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1731122155,
-        "narHash": "sha256-kS/FbbDnrtmXl3fLGAUiWpLBJYF6S2glnugVLWMjkPQ=",
+        "lastModified": 1732237046,
+        "narHash": "sha256-OspNYf40dhI3nA+AUIOTX1yeCovyla/yS1nlk26xG6U=",
         "owner": "DeterminateSystems",
         "repo": "nixpkgs",
-        "rev": "f429e17f022e9c0430fa13d42433dfa2d27eef84",
+        "rev": "5dff3c86ecbd16e60c7217e244aafa72d7036707",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:DeterminateSystems/nixpkgs?ref=colemickens/ec2";
-    determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/0.1.95";
+    determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/0.1.*.tar.gz";
     fh.url = "https://flakehub.com/f/DeterminateSystems/fh/0.1.*";
     flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/0.1.5";
     nixos-amis.url = "https://flakehub.com/f/NixOS/amis/0.1.*";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'determinate':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.147%2Brev-afd03f6548b1e86c2f2aa23c35a7672221605b82/0192e258-0fd2-7ce1-82d3-7dde592ec98f/source.tar.gz?narHash=sha256-5xEvS8jWbNtOY8ifGxuS8Nai9oUfTGXy5kGzy29syFU%3D' (2024-10-31)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.159%2Brev-29b7b7dfb1c878267383aa91c357ef464bef0f0d/01935106-420e-7097-93f6-ef4f1b11ffde/source.tar.gz?narHash=sha256-tuqod7g%2B1%2BPvtUXUlLl4MwY9B%2Bgr4rAEOGvhmhtWLbE%3D' (2024-11-21)
• Updated input 'determinate/determinate-nixd-aarch64-darwin':
    'https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/macOS?narHash=sha256-OhG8joS/uN3Kdw4h9w8F/6ZIVTFZ8J9Fb4NGn/KK5/s%3D'
  → 'https://install.determinate.systems/determinate-nixd/tag/v0.2.4/macOS?narHash=sha256-6E9DFC4lTpjmErG2TvV7rIS1tiyGZZYg0Kd4pT5GOkU%3D'
• Updated input 'determinate/determinate-nixd-aarch64-linux':
    'https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/aarch64-linux?narHash=sha256-AGcHQSIdb%2BKEJlhJzMB4YyFxbjdLZEDDf6bv6Zi3wqM%3D'
  → 'https://install.determinate.systems/determinate-nixd/tag/v0.2.4/aarch64-linux?narHash=sha256-CnbFYAL7dAl8qBIvAFMVjW4KpQgmWlghnK3qfoLEP8Q%3D'
• Updated input 'determinate/determinate-nixd-x86_64-linux':
    'https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/x86_64-linux?narHash=sha256-kU4dqHoYe3sFf4LDAUj4fyl9uGV8IHtE22%2BDdMeRN0s%3D'
  → 'https://install.determinate.systems/determinate-nixd/tag/v0.2.4/x86_64-linux?narHash=sha256-0w3gbvncDwukX4PHVWeOZeD6F6vsEuePoNOIlAvdEq0%3D'
• Updated input 'determinate/nixpkgs':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.697431%2Brev-86e78d3d2084ff87688da662cf78c2af085d8e73/0192d6c6-ebf3-7285-bc0c-0fb71cc054e0/source.tar.gz?narHash=sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY%3D' (2024-10-26)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.709559%2Brev-5083ec887760adfe12af64830a66807423a859a7/019342ec-4762-77f2-9a11-86e7601b0be4/source.tar.gz?narHash=sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs%3D' (2024-11-18)
• Updated input 'fh':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/fh/0.1.18/01927139-f320-7ec6-b217-f3d2004955b8/source.tar.gz?narHash=sha256-McfJXbr/oadsfQV7hzB6sEMy9sfXthHcjsbOiQs2%2BrU%3D' (2024-10-08)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/fh/0.1.19/0193038e-7bda-7db1-954f-cbb2e2963d0f/source.tar.gz?narHash=sha256-QFlNSjrXU4vdiAYylS4UmDmaOcqcz9ujo0mkj4LStAo%3D' (2024-11-06)
• Updated input 'fh/fenix':
    'https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.1986%2Brev-28b42d01f549c38bd165296fbcb4fe66d98fc24f/0191aca7-e3ea-728d-bfd8-c4744f4a108d/source.tar.gz?narHash=sha256-BtLY9lWu/pe6/ImFwuRRRqMwLacY5AZOKA2hUHUQ64k%3D' (2024-09-01)
  → 'https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2029%2Brev-a9d2e5fa8d77af05240230c9569bbbddd28ccfaf/01924729-44b5-7df4-a70d-d5e64656e243/source.tar.gz?narHash=sha256-tvN9v5gTxLI5zOKsNvYl1aUxIitHm8Nj3vKdXNfJo50%3D' (2024-10-01)
• Updated input 'fh/fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/914a1caab54e48a028b2407d0fe6fade89532f67?narHash=sha256-TBujPMMIv8RG6BKlsBEpCln1ePmWz79xTcJOQpU2L18%3D' (2024-08-31)
  → 'github:rust-lang/rust-analyzer/28830ff2f1158ee92f4852ef3ec35af0935d1562?narHash=sha256-xxgUHwwJ%2B1xQQoUWvLDo807IZ0MDldkfr9N1G4fvNJU%3D' (2024-09-30)
• Updated input 'fh/nixpkgs':
    'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.681973%2Brev-99dc8785f6a0adac95f5e2ab05cc2e1bf666d172/0191fe06-77c6-7f96-9835-e6a8ac5c4059/source.tar.gz?narHash=sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c%3D' (2024-09-16)
  → 'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.696158%2Brev-2768c7d042a37de65bb1b5b3268fc987e534c49d/0192bd28-d6c0-735c-ab86-8ab9d12f7d62/source.tar.gz?narHash=sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4%3D' (2024-10-23)
• Updated input 'nixos-amis':
    'github:NixOS/amis/d4a56fc853c3223f7e0a90f23205f18f2982a368?narHash=sha256-7Z7V%2BQblWsPxcP57Y/FNEJIyETWZxYDLIIdvi1GBU9I%3D' (2024-10-24)
  → 'github:NixOS/amis/b22b21357cf24d687c2cef4baf5011915124857a?narHash=sha256-kQWe2AZylGGODw99J%2BY/NWdronPBuj11XuF5GS102bk%3D' (2024-11-18)