### PR TITLE
update determinate + nixpkgs, push new images

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -395,11 +395,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1732237046,
-        "narHash": "sha256-OspNYf40dhI3nA+AUIOTX1yeCovyla/yS1nlk26xG6U=",
+        "lastModified": 1733964348,
+        "narHash": "sha256-j9gKgRX/J8yy+mjWefniRDFskrlPJn8YqOoUbALU964=",
         "owner": "DeterminateSystems",
         "repo": "nixpkgs",
-        "rev": "5dff3c86ecbd16e60c7217e244aafa72d7036707",
+        "rev": "6215e1e89982a07cd05e4881fa08c379c6d68e2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'determinate':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.159%2Brev-29b7b7dfb1c878267383aa91c357ef464bef0f0d/01935106-420e-7097-93f6-ef4f1b11ffde/source.tar.gz?narHash=sha256-tuqod7g%2B1%2BPvtUXUlLl4MwY9B%2Bgr4rAEOGvhmhtWLbE%3D' (2024-11-21)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.165%2Brev-657395244a854da1bc71e38454958ecd57c0e241/0193b781-6c27-7703-bca6-fc9648fca81d/source.tar.gz?narHash=sha256-nUTutqzg/Z0eEXrC1ACTa4a9Ik5Iyxgqo8uL9DYib7I%3D' (2024-12-11)
• Updated input 'determinate/determinate-nixd-aarch64-darwin':
    'https://install.determinate.systems/determinate-nixd/tag/v0.2.4/macOS?narHash=sha256-6E9DFC4lTpjmErG2TvV7rIS1tiyGZZYg0Kd4pT5GOkU%3D'
  → 'https://install.determinate.systems/determinate-nixd/tag/v0.2.6/macOS?narHash=sha256-I03XaJRNQHh/N3ea2qpMU78DahTm7tSfF%2BurRABhKiQ%3D'
• Updated input 'determinate/determinate-nixd-aarch64-linux':
    'https://install.determinate.systems/determinate-nixd/tag/v0.2.4/aarch64-linux?narHash=sha256-CnbFYAL7dAl8qBIvAFMVjW4KpQgmWlghnK3qfoLEP8Q%3D'
  → 'https://install.determinate.systems/determinate-nixd/tag/v0.2.6/aarch64-linux?narHash=sha256-yxF7hyInOc%2BS1BEaxjLBLHUFjSAjC0bRKh0glUt4ilo%3D'
• Updated input 'determinate/determinate-nixd-x86_64-linux':
    'https://install.determinate.systems/determinate-nixd/tag/v0.2.4/x86_64-linux?narHash=sha256-0w3gbvncDwukX4PHVWeOZeD6F6vsEuePoNOIlAvdEq0%3D'
  → 'https://install.determinate.systems/determinate-nixd/tag/v0.2.6/x86_64-linux?narHash=sha256-/LPSCwR/ueorahCcyUSVym3y3lnRXkc6pqWwW2T/yT8%3D'
• Updated input 'determinate/nix':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/nix/2.24.10/0192e251-cc5a-7b3c-8339-faf088a24136/source.tar.gz?narHash=sha256-y1z53C9%2ByH1LUCWuouuA0i4vzXEAm8bmK0gyNAY/fyc%3D' (2024-10-31)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/nix/2.25.3/01939864-5191-788c-b898-163d916a3333/source.tar.gz?narHash=sha256-rOFE8TSwWoup%2BLPNbmtTs6oLy7lYZ12L9GN%2BaZuQQaA%3D' (2024-12-03)
• Updated input 'determinate/nix/nix':
    'https://api.flakehub.com/f/pinned/NixOS/nix/2.24.10/0192e247-90bb-7e27-ba8d-f7ee8344a03e/source.tar.gz?narHash=sha256-XdeVy1/d6DEIYb3nOA6JIYF4fwMKNxtwJMgT3pHi%2Bko%3D' (2024-10-30)
  → 'https://api.flakehub.com/f/pinned/NixOS/nix/2.25.3/01938786-bc70-79e3-b7ee-bb61f8e7f238/source.tar.gz?narHash=sha256-T%2BwFMm3cj8pGJSwXmPuxG5pz%2B1gRDJoToF9OBxtzocA%3D' (2024-11-29)
• Updated input 'determinate/nix/nixpkgs':
    'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.636213%2Brev-64b80bfb316b57cdb8919a9110ef63393d74382a/0192d84c-b6fc-7e39-a326-c46cc00f5b6a/source.tar.gz?narHash=sha256-9z8oOgFZiaguj%2Bbbi3k4QhAD6JabWrnv7fscC/mt0KE%3D' (2024-10-28)
  → 'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.710194%2Brev-f9f0d5c5380be0a599b1fb54641fa99af8281539/01938be8-64ce-75c6-94d4-dbc2e4d547fe/source.tar.gz?narHash=sha256-En%2BgSoVJ3iQKPDU1FHrR6zIxSLXKjzKY%2Bpnh9tt%2BYts%3D' (2024-12-02)
• Updated input 'determinate/nixpkgs':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.709559%2Brev-5083ec887760adfe12af64830a66807423a859a7/019342ec-4762-77f2-9a11-86e7601b0be4/source.tar.gz?narHash=sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs%3D' (2024-11-18)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.719099%2Brev-dd51f52372a20a93c219e8216fe528a648ffcbf4/0193af12-b91a-77b9-9c72-3172a023752d/source.tar.gz?narHash=sha256-NQEO/nZWWGTGlkBWtCs/1iF1yl2lmQ1oY/8YZrumn3I%3D' (2024-12-08)
• Updated input 'fh':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/fh/0.1.19/0193038e-7bda-7db1-954f-cbb2e2963d0f/source.tar.gz?narHash=sha256-QFlNSjrXU4vdiAYylS4UmDmaOcqcz9ujo0mkj4LStAo%3D' (2024-11-06)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/fh/0.1.21/01939cd9-0100-787a-b2e7-3c5db5c31b04/source.tar.gz?narHash=sha256-EepDB25iZ8li%2BfGwhqOqg7XipFBishv4SvcDE2FE%2Bis%3D' (2024-12-06)
• Updated input 'fh/nixpkgs':
    'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.696158%2Brev-2768c7d042a37de65bb1b5b3268fc987e534c49d/0192bd28-d6c0-735c-ab86-8ab9d12f7d62/source.tar.gz?narHash=sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4%3D' (2024-10-23)
  → 'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.710050%2Brev-62c435d93bf046a5396f3016472e8f7c8e2aed65/01938188-9ae4-7095-9c6e-c6e2ce4adf18/source.tar.gz?narHash=sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT%2B34%3D' (2024-11-30)
• Updated input 'nixos-amis':
    'https://api.flakehub.com/f/pinned/NixOS/amis/0.1.216%2Brev-b22b21357cf24d687c2cef4baf5011915124857a/01933eda-5dd7-7ea0-8e93-c8cb9409600e/source.tar.gz?narHash=sha256-kQWe2AZylGGODw99J%2BY/NWdronPBuj11XuF5GS102bk%3D' (2024-11-18)
  → 'https://api.flakehub.com/f/pinned/NixOS/amis/0.1.217%2Brev-e88cec7bbeebbe2aa916cfc8f846bd3897a600c1/01938d4c-0497-7e22-a060-325b1f1ddec0/source.tar.gz?narHash=sha256-smuy1oZUbK9ZVdcKO1eNV8%2B60IwulAuHtvs3P09dc3s%3D' (2024-12-03)

flake: update for determinate input