### PR TITLE
fix label regression

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
             --image-info "./result/nix-support/image-info.json" \
             --prefix "${prefix}" \
             --s3-bucket "detsys-nixos-images-20240916205705854200000001" \
-            --run-id '${{ steps.build-disk-image.outputs.suffix }}' \
+            --run-id "${{ github.run_id }}-${{ github.run_attempt }}" \
             --copy-to-regions \
             --public
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,12 +32,14 @@
         modules = [
           "${inputs.nixpkgs}/nixos/maintainers/scripts/ec2/amazon-image.nix"
           inputs.determinate.nixosModules.default
-          {
+          ({ config, ... }: {
+
+            system.nixos.tags = lib.mkForce [ ];
             environment.systemPackages = [
               inputs.fh.packages.${system}.default
               pkgs.git
             ];
-          }
+          })
         ];
       });
 


### PR DESCRIPTION
1. They didn't have `system.nixos.tags` set previously
2. They use `config.system.nixos.label` to form the `system_label` put into the support json file, used by `upload_ami`.
3. With tags set to `["amazon"]` (see: https://github.com/NixOS/nixpkgs/commit/fdb144fb411b31aa2829d00ccfc9ddafe3ccd0f6#diff-15d957b64e4bcfadbe6317cb441ec661eacac936af6e918f289cfffbb46444edL175), the label becomes prefixed with `amazon-[stateVersion]` instead of just `[stateVersion]`.

I left the traces in there, but this gets the image name back to starting with `stateVersion`.

I think this is what we want, I say we merge and confirm. Then I'll chase with workflow assurances-checks. 