### PR TITLE
nixos-amis: Create a propose-release workflow, for good measure

### DIFF
--- a/.github/workflows/propose-release.yml
+++ b/.github/workflows/propose-release.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_dispatch:
+    inputs:
+      reference-id:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  propose-release:
+    uses: DeterminateSystems/propose-release/.github/workflows/workflow.yml@main
+    permissions:
+      id-token: "write"
+      contents: "write"
+      pull-requests: write
+    with:
+      reference-id: ${{ inputs.reference-id }}
+      version: ${{ inputs.version }}


### PR DESCRIPTION
This is pretty similar to the update workflow that runs on a cron, but adding this will make it easier to integrate. When I originally did #41 I was going to do something special for this repo, but there really isn't any reason to.