### PR TITLE
Update the EUSC AWS roles and bucket names in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,7 +168,7 @@ jobs:
             region: us-east-2
           - role: arn:aws-us-gov:iam::579351485434:role/upload-ami
             region: us-gov-west-1
-          - role: arn:aws-eusc:iam::111921064076:role/upload-ami
+          - role: arn:aws-eusc:iam::129194717446:role/upload-ami
             region: eusc-de-east-1
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,9 +71,9 @@ jobs:
           - role: arn:aws-us-gov:iam::579351485434:role/upload-ami
             region: us-gov-west-1
             bucket: detsys-nixos-images-20260303190747195900000001
-          - role: arn:aws-eusc:iam::111921064076:role/upload-ami
+          - role: arn:aws-eusc:iam::129194717446:role/upload-ami
             region: eusc-de-east-1
-            bucket: detsys-nixos-images-20260304164532954800000001
+            bucket: detsys-nixos-images-20260409030044091900000001
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -107,13 +107,17 @@ data "aws_ami" "detsys_nixos" {
 > [!NOTE]
 > The Terraform configuration below is compatible with [OpenTofu] as well.
 
+> [!NOTE]
+> We previously published EUSC AMIs to the AWS account `111921064076`.
+> The correct AWS account for the European Sovereign Cloud AMIs is `129194717446` as of 2026-04-08.
+
 You can use our official AMI for NixOS in a [Terraform] configuration like this:
 
 ```hcl
 data "aws_ami" "detsys_nixos" {
   most_recent = true
 
-  owners      = [ "111921064076" ]
+  owners      = [ "129194717446" ]
 
   filter {
     name   = "name"


### PR DESCRIPTION
This moves the AMI publication for AWS EUSC to a new AWS account exclusively dedicated to publishing AMIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cloud deployment workflow for a specific partition to use a refreshed upload role and storage target for AMI build and pruning; scoped to that partition only, no other workflow logic changed.
* **Documentation**
  * Clarified README note about the current European Sovereign Cloud AMI owner and updated the Terraform example to reference the new owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->